### PR TITLE
Fix debugging for forking process run on a remote machine

### DIFF
--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -6,7 +6,7 @@ if (RUBY_VERSION < '2.0')
   require 'ruby-debug-base'
 else
   require 'debase'
-end  
+end
 
 require 'ruby-debug-ide/version'
 require 'ruby-debug-ide/xml_printer'
@@ -14,7 +14,7 @@ require 'ruby-debug-ide/ide_processor'
 require 'ruby-debug-ide/event_processor'
 
 module Debugger
-  
+
   class << self
     # Prints to the stderr using printf(*args) if debug logging flag (-d) is on.
     def print_debug(*args)
@@ -25,7 +25,7 @@ module Debugger
         $stderr.flush
       end
     end
-    
+
     def cleanup_backtrace(backtrace)
        cleared = []
        return cleared unless backtrace
@@ -40,12 +40,12 @@ module Debugger
        end
        cleared
     end
-    
+
     attr_accessor :cli_debug, :xml_debug
     attr_accessor :control_thread
     attr_reader :interface
 
-    
+
     #
     # Interrupts the last debugged thread
     #
@@ -69,10 +69,10 @@ module Debugger
       start_server(options.host, options.port)
 
       raise "Control thread did not start (#{@control_thread}}" unless @control_thread && @control_thread.alive?
-      
+
       @mutex = Mutex.new
       @proceed = ConditionVariable.new
-      
+
       # wait for 'start' command
       @mutex.synchronize do
         @proceed.wait(@mutex)
@@ -89,14 +89,14 @@ module Debugger
         $stderr.print Debugger.cleanup_backtrace(bt.backtrace).map{|l| "\t#{l}"}.join("\n"), "\n"
       end
     end
-    
+
     def run_prog_script
       return unless @mutex
       @mutex.synchronize do
         @proceed.signal
       end
     end
-    
+
     def start_control(host, port)
       raise "Debugger is not started" unless started?
       return if @control_thread
@@ -110,11 +110,12 @@ module Debugger
           $stderr.printf "Fast Debugger (ruby-debug-ide #{IDE_VERSION}, #{gem_name} #{VERSION}) listens on #{host}:#{port}\n"
           server = TCPServer.new(host, port)
           while (session = server.accept)
-            $stderr.puts "Connected from #{session.addr[2]}" if Debugger.cli_debug
+            $stderr.puts "Connected from #{session.peeraddr[2]}" if Debugger.cli_debug
             dispatcher = ENV['IDE_PROCESS_DISPATCHER']
             if (dispatcher)
-              ENV['IDE_PROCESS_DISPATCHER'] = "#{session.addr[2]}:#{dispatcher}" unless dispatcher.include?(":")
-            end  
+              ENV['IDE_PROCESS_DISPATCHER'] = "#{session.peeraddr[2]}:#{dispatcher}" unless dispatcher.include?(":")
+              ENV['DEBUGGER_HOST'] = host
+            end
             begin
               @interface = RemoteInterface.new(session)
               self.handler = EventProcessor.new(interface)
@@ -132,9 +133,9 @@ module Debugger
         end
       end
     end
-    
+
   end
-  
+
   class Exception # :nodoc:
     attr_reader :__debug_file, :__debug_line, :__debug_binding, :__debug_context
   end

--- a/lib/ruby-debug-ide/multiprocess/pre_child.rb
+++ b/lib/ruby-debug-ide/multiprocess/pre_child.rb
@@ -5,10 +5,10 @@ module Debugger
 
         require "socket"
         require "ostruct"
-        
-        host = '127.0.0.1'
+
+        host = ENV['DEBUGGER_HOST']
         port = find_free_port(host)
-      
+
         options = OpenStruct.new(
             'frame_bind'  => false,
             'host'        => host,
@@ -18,10 +18,10 @@ module Debugger
             'tracing'     => false,
             'int_handler' => true
         )
-      
+
         acceptor_host, acceptor_port = ENV['IDE_PROCESS_DISPATCHER'].split(":")
         acceptor_host, acceptor_port = '127.0.0.1', acceptor_host unless acceptor_port
-  
+
         connected = false
         3.times do |i|
           begin
@@ -39,28 +39,28 @@ module Debugger
           end unless connected
         end
       end
-      
+
       def start_debugger(options)
         if Debugger.started?
           #we're in forked child, only need to restart control thread
-          Debugger.breakpoints.clear 
+          Debugger.breakpoints.clear
           Debugger.control_thread = nil
           Debugger.start_control(options.host, options.port)
         end
-  
+
         if options.int_handler
           # install interruption handler
           trap('INT') { Debugger.interrupt_last }
         end
-      
+
         # set options
         Debugger.keep_frame_binding = options.frame_bind
-        Debugger.tracing = options.tracing             
-        
+        Debugger.tracing = options.tracing
+
         Debugger.prepare_debugger(options)
       end
-  
-  
+
+
       def find_free_port(host)
         server = TCPServer.open(host, 0)
         port   = server.addr[1]


### PR DESCRIPTION
When remote debugging on a remote machine, pre_child will fail to properly setup the debugger. `TCPSocket.open(acceptor_host, acceptor_port)` will always fail to connect and the remote client will not be able to connect to the new control thread listening on localhost. 

Fix this by: 
- Using `peeraddr` rather than `addr` so that pre_child can connect back to the dispatcher
- Using the `host` arg that rdebug-ide uses rather than 127.0.0.1 as the host so that the client can connect to the newly opened debugger

Hopefully I haven't overlooked something vital, but this change allows me to debug e.g. rails apps when running via unicorn rather than WEBrick/Thin. 
