### PR TITLE
we always should load ruby-debug-base for JRuby

### DIFF
--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -2,7 +2,7 @@ require 'pp'
 require 'stringio'
 require "socket"
 require 'thread'
-if (RUBY_VERSION < '2.0')
+if (RUBY_VERSION < '2.0' || defined?(JRUBY_VERSION))
   require 'ruby-debug-base'
 else
   require 'debase'


### PR DESCRIPTION
this change fix first problem we have with debugging JRuby with language level 2.0.
But after that I've got the following exception which means ruby-debug-base should also be patched for this language level.
Util.java:122:in `typeForEvent': java.lang.IllegalArgumentException: unknown event type: b-return
    from DebugEventHook.java:97:in`eventHandler'
    from EventHook.java:30:in `event'
    from Ruby.java:2882:in`callEventHooks'
    from ThreadContext.java:629:in `trace'
    from ThreadContext.java:625:in`trace'
    from ASTInterpreter.java:140:in `blockPostTrace'
    from ASTInterpreter.java:114:in`INTERPRET_BLOCK'
    from Interpreted19Block.java:206:in `evalBlockBody'
    from Interpreted19Block.java:194:in`yield'
    from Interpreted19Block.java:125:in `call'
    from Block.java:101:in`call'
    from RubyProc.java:274:in `call'
    from RubyProc.java:215:in`call'
    from Ruby.java:2973:in `tearDown'
    from Ruby.java:2957:in`tearDown'
    from Main.java:282:in `internalRun'
    from Main.java:221:in`run'
    from Main.java:201:in `main'
