### PR TITLE
Need to pass cli_debug flag to a child process

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -95,6 +95,7 @@ if options.dispatcher_port != -1
   old_opts = ENV['RUBYOPT']
   ENV['RUBYOPT'] = "-r#{File.expand_path(File.dirname(__FILE__))}/../lib/ruby-debug-ide/multiprocess/starter"
   ENV['RUBYOPT'] += " #{old_opts}" if old_opts
+  ENV['DEBUGGER_CLI_DEBUG'] = Debugger.cli_debug
 end
 
 if options.int_handler

--- a/lib/ruby-debug-ide/multiprocess/pre_child.rb
+++ b/lib/ruby-debug-ide/multiprocess/pre_child.rb
@@ -16,7 +16,8 @@ module Debugger
             'port'        => port,
             'stop'        => false,
             'tracing'     => false,
-            'int_handler' => true
+            'int_handler' => true,
+            'cli_debug'   => (ENV['DEBUGGER_CLI_DEBUG'] == 'true')
         )
 
         acceptor_host, acceptor_port = ENV['IDE_PROCESS_DISPATCHER'].split(":")
@@ -56,6 +57,7 @@ module Debugger
         # set options
         Debugger.keep_frame_binding = options.frame_bind
         Debugger.tracing = options.tracing
+        Debugger.cli_debug = options.cli_debug
 
         Debugger.prepare_debugger(options)
       end


### PR DESCRIPTION
Currently child process doesn't print debug information and thus it is hard to investigate problems with multi-process debugging
