### PR TITLE
Support path translation for remote debugging path name mismatch

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -46,6 +46,15 @@ EOB
   opts.on("-I", "--include PATH", String, "Add PATH to $LOAD_PATH") do |path|
     $LOAD_PATH.unshift(path)
   end
+
+  opts.on("-t", '--path-translation FROM=TO', String, 'Add path tranlation map') do |tstr|
+    pmap = tstr.split('=', 2)
+    if pmap[0].empty? || pmap[1].nil? || pmap[1].empty?
+      $stderr.puts "Wrong path translation format: #{tstr}"
+      exit 100
+    end
+    Debugger.path_translations << pmap
+  end
   
   opts.on("--keep-frame-binding", "Keep frame bindings") {options.frame_bind = true}
   opts.on("--disable-int-handler", "Disables interrupt signal handler") {options.int_handler = false}

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -14,6 +14,7 @@ require 'ruby-debug-ide/ide_processor'
 require 'ruby-debug-ide/event_processor'
 
 module Debugger
+  @path_translations = []
 
   class << self
     # Prints to the stderr using printf(*args) if debug logging flag (-d) is on.
@@ -43,6 +44,7 @@ module Debugger
 
     attr_accessor :cli_debug, :xml_debug
     attr_accessor :control_thread
+    attr_accessor :path_translations
     attr_reader :interface
 
 

--- a/lib/ruby-debug-ide/ide_processor.rb
+++ b/lib/ruby-debug-ide/ide_processor.rb
@@ -84,6 +84,13 @@ module Debugger
       while input = @interface.read_command
         # escape % since print_debug might use printf
         # sleep 0.3
+        if input[0, 2] == 'b '
+          path = input[2..-1]
+          Debugger.path_translations.each do |pmap|
+            path.gsub!(pmap[0], pmap[1])
+          end
+          input = 'b ' + path
+        end
         catch(:debug_error) do
           if cmd = ctrl_cmds.find{|c| c.match(input) }
             @printer.print_debug "Processing in control: #{input.gsub('%', '%%')}"

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -79,7 +79,7 @@ module Debugger
       # idx + 1: one-based numbering as classic-debugger
       file = context.frame_file(frame_id)
       print "<frame no=\'%s\' file=\'%s\' line=\'%s\' #{"current='true' " if frame_id == current_frame_id}/>",
-        frame_id + 1, File.expand_path(file), context.frame_line(frame_id)
+        frame_id + 1, expand_path(file), context.frame_line(frame_id)
     end
     
     def print_contexts(contexts)
@@ -273,7 +273,7 @@ module Debugger
     
     def print_at_line(context, file, line)
       print "<suspended file=\'%s\' line=\'%s\' threadId=\'%d\' frames=\'%d\'/>",
-        File.expand_path(file), line, context.thnum, context.stack_size
+        expand_path(file), line, context.thnum, context.stack_size
     end
     
     def print_exception(exception, binding)
@@ -321,6 +321,14 @@ module Debugger
       if m.to_s.index('print_') == 0
         protect m
       end
+    end
+
+    def expand_path(path)
+      p = File.expand_path(path)
+      Debugger.path_translations.reverse.each do |pmap|
+        p.gsub!(pmap[1], pmap[0])
+      end
+      p
     end
     
   end


### PR DESCRIPTION
This patch add -t --path-translation option to resolve path
mismatch on remote debugging with network mounted filesystem.

For example:
- A ruby app is running on Linux host A under /home/you/app
- You use IDE on Windows to edit the app on network
  mounted host A, /home/you to drive H: via samba.

In this case, some IDE can make debug connection, but they
will send break point with local path (H:\app...).

To resolve this issue, I propose to add path translation
option on rdebug-ide side, like;

 rdebug-ide -t '\=/' -t 'H:=/home/you' app/runner

This means replace string in path with two rules
(\ -> / and H: -> /home/you). It make debug works on
IDE that has no path mapping feature.
