### PR TITLE
value-as-sub-element

### DIFF
--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -170,9 +170,11 @@ module Debugger
         end 
       end
       value_str = "[Binary Data]" if (value_str.respond_to?('is_binary_data?') && value_str.is_binary_data?)
-      print("<variable name=\"%s\" kind=\"%s\" value=\"%s\" type=\"%s\" hasChildren=\"%s\" objectId=\"%#+x\"/>",
+      print("<variable name=\"%s\" kind=\"%s\" value=\"%s\" type=\"%s\" hasChildren=\"%s\" objectId=\"%#+x\">",
           CGI.escapeHTML(name), kind, CGI.escapeHTML(value_str), value.class,
           has_children, value.respond_to?(:object_id) ? value.object_id : value.id)
+      print("<value><![CDATA[%s]]></value>", value_str)
+      print('</variable>')
     end
     
     def print_breakpoints(breakpoints)

--- a/test-base/variables_test.rb
+++ b/test-base/variables_test.rb
@@ -25,7 +25,7 @@ module VariablesTest
       {:name => "stringA"},
       {:name => "testHashValue"})
     # will receive ''
-    assert_xml("<start test=\"&\"/>", variables[0].value)
+    assert_equal("<start test=\"&\"/>", variables[0].value)
     assert_local(variables[0])
     # the testHashValue contains an example, where the name consists of special
     # characters


### PR DESCRIPTION
To pass \n and other chars which can not be passed in attribute value
we need to pass variable's value as text in sub-element
