### PR TITLE
Add IntelliJ IDEA Ruby plugin to usage text.

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -24,8 +24,9 @@ options = OpenStruct.new(
 opts = OptionParser.new do |opts|
   opts.banner = <<EOB
 Using ruby-debug-base #{Debugger::VERSION}
-Usage: rdebug-ide is supposed to be called from RDT, NetBeans or RubyMine. The
-       command line interface to ruby-debug is rdebug.
+Usage: rdebug-ide is supposed to be called from RDT, NetBeans, RubyMine, or
+       the IntelliJ IDEA Ruby plugin.  The command line interface to
+       ruby-debug is rdebug.
 EOB
   opts.separator ""
   opts.separator "Options:"


### PR DESCRIPTION
Since the IntelliJ IDEA Ruby plugin is supported, I think the usage text should be updated to reflect that.
