### PR TITLE
Evaluation timeout has been made configurable

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -18,7 +18,8 @@ options = OpenStruct.new(
   'stop'        => false,
   'tracing'     => false,
   'int_handler' => true,
-  'dispatcher_port' => -1
+  'dispatcher_port' => -1,
+  'evaluation_timeout' => 10
 )
 
 opts = OptionParser.new do |opts|
@@ -34,7 +35,10 @@ EOB
   opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}  
   opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 
     options.dispatcher_port = dp
-  end  
+  end
+  opts.on('--evaluation-timeout TIMEOUT', Integer,'evaluation timeout in seconds (default: 10)') do |timeout|
+    options.evaluation_timeout = timeout
+  end
   opts.on('--stop', 'stop when the script is loaded') {options.stop = true}
   opts.on("-x", "--trace", "turn on line tracing") {options.tracing = true}
   opts.on("-l", "--load-mode", "load mode (experimental)") {options.load_mode = true}
@@ -107,6 +111,7 @@ end
 # set options
 Debugger.keep_frame_binding = options.frame_bind
 Debugger.tracing = options.tracing
+Debugger.evaluation_timeout = options.evaluation_timeout
 
 Debugger.debug_program(options)
 

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -41,7 +41,7 @@ module Debugger
        cleared
     end
 
-    attr_accessor :cli_debug, :xml_debug
+    attr_accessor :cli_debug, :xml_debug, :evaluation_timeout
     attr_accessor :control_thread
     attr_reader :interface
 

--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -115,7 +115,7 @@ module Debugger
     def debug_eval(str, b = get_binding)
       begin
         str = str.to_s
-        max_time = 10
+        max_time = Debugger.evaluation_timeout
         to_inspect = str.gsub(/\\n/, "\n")
         @printer.print_debug("Evaluating #{str} with timeout after %i sec", max_time)
         timeout(max_time) do


### PR DESCRIPTION
RubyMine allows to configure evaluation timeout, it would be nice to pass this setting to the gem too (see http://youtrack.jetbrains.com/issue/RUBY-13051)
