### PR TITLE
Fix dependencies for ruby 1.9.3

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -19,10 +19,8 @@ unless jruby || rbx
 
   if RUBY_VERSION < "1.9"
     dep = Gem::Dependency.new("ruby-debug-base", '>=0.10.4')
-  elsif RUBY_VERSION >= '1.9.3'
-    dep = Gem::Dependency.new("ruby-debug-base19x", '>=0.11.30.pre15')
   elsif RUBY_VERSION < '2.0'
-    dep = Gem::Dependency.new("ruby-debug-base19x", '>=0.11.24')
+    dep = Gem::Dependency.new("ruby-debug-base19x", '>=0.11.30.pre15')
   else    
     dep = Gem::Dependency.new("debase", '> 0')
   end


### PR DESCRIPTION
This is a candidate fix for https://github.com/ruby-debug/ruby-debug-ide/issues/56.

If ruby 1.9.3 is detected, it will force the usage to 0.11.30.pre15 or later. I admit it isn't a perfect solution for those who would like only "stable" gems but I think that, pragmatically, it's an okay fix considering that:
- those gems are usually installed in the context of development
- the ruby-debug-base19x gems have remained in the prerelease state for a long time

Also, on a side note, I was tempted to move the dependency selection block in the begin block so that this whole if block doesn't get executed at all if the current ruby gem dependency requirements are met, but I stopped there, aiming for a minimal fix to facilitate a quick review...
