### PR TITLE
Expect escaped backslashes in expressions to inspect

### DIFF
--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -66,8 +66,8 @@ module Debugger
       end
 
       def unescape_incoming(str)
-        str.gsub(/((?:^|[^\\])(?:\\\\)*)\\n/, "\\1\n")
-            .gsub(/\\\\/, '\\')
+        str.gsub(/((?:^|[^\\])(?:\\\\)*)\\n/, "\\1\n").
+            gsub(/\\\\/, '\\')
       end
     end
     

--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -108,8 +108,8 @@ module Debugger
     def debug_eval(str, b = get_binding)
       begin
         str = str.to_s
+        to_inspect = unescape_incoming(str)
         max_time = Debugger.evaluation_timeout
-        to_inspect = str.gsub(/\\n/, "\n")
         @printer.print_debug("Evaluating #{str} with timeout after %i sec", max_time)
         timeout(max_time) do
           eval(to_inspect, b)
@@ -118,6 +118,11 @@ module Debugger
         @printer.print_exception(e, @state.binding) 
         throw :debug_error
       end
+    end
+
+    def unescape_incoming(str)
+        str.gsub(/(?<backsl_escapes>(?:^|[^\\])(?:\\\\)*)\\n/, "\\k<backsl_escapes>\n")
+           .gsub(/\\\\/, '\\')
     end
 
     def debug_silent_eval(str)

--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -64,6 +64,11 @@ module Debugger
       def options
         @options ||= {}
       end
+
+      def unescape_incoming(str)
+        str.gsub(/((?:^|[^\\])(?:\\\\)*)\\n/, "\\1\n")
+            .gsub(/\\\\/, '\\')
+      end
     end
     
     def initialize(state, printer)
@@ -104,11 +109,11 @@ module Debugger
         y.kill if y and y.alive?
       end
     end
-    
+
     def debug_eval(str, b = get_binding)
       begin
         str = str.to_s
-        to_inspect = unescape_incoming(str)
+        to_inspect = Command.unescape_incoming(str)
         max_time = Debugger.evaluation_timeout
         @printer.print_debug("Evaluating #{str} with timeout after %i sec", max_time)
         timeout(max_time) do
@@ -118,11 +123,6 @@ module Debugger
         @printer.print_exception(e, @state.binding) 
         throw :debug_error
       end
-    end
-
-    def unescape_incoming(str)
-        str.gsub(/(?<backsl_escapes>(?:^|[^\\])(?:\\\\)*)\\n/, "\\k<backsl_escapes>\n")
-           .gsub(/\\\\/, '\\')
     end
 
     def debug_silent_eval(str)

--- a/lib/ruby-debug-ide/commands/expression_info.rb
+++ b/lib/ruby-debug-ide/commands/expression_info.rb
@@ -9,7 +9,7 @@ module Debugger
     end
 
     def execute
-      string_to_parse = @match.post_match.gsub("\\n", "\n") + "\n\n\n"
+      string_to_parse = unescape_incoming(@match.post_match) + "\n\n\n"
       total_lines = string_to_parse.count("\n") + 1
 
       lexer = RubyLex.new

--- a/lib/ruby-debug-ide/commands/expression_info.rb
+++ b/lib/ruby-debug-ide/commands/expression_info.rb
@@ -13,23 +13,7 @@ module Debugger
       total_lines = string_to_parse.count("\n") + 1
 
       lexer = RubyLex.new
-      io = StringIO.new(string_to_parse)
-
-      begin
-        encoding = string_to_parse.encoding
-      rescue
-        encoding = 'None'
-      end
-
-      # for passing to the lexer
-      io.instance_exec(encoding) do |string_encoding|
-        @my_encoding = string_encoding
-        def self.encoding
-          @my_encoding
-        end
-      end
-
-      lexer.set_input(io)
+      lexer.set_input(create_io_reader(string_to_parse))
 
       last_statement = ''
       last_prompt = ''
@@ -51,6 +35,21 @@ module Debugger
       end
 
       @printer.print_expression_info(incomplete, last_prompt, last_indent)
+    end
+
+    def create_io_reader(string_to_parse)
+      io = StringIO.new(string_to_parse)
+
+      if string_to_parse.respond_to?(:encoding)
+        io.instance_exec(string_to_parse.encoding) do |string_encoding|
+          @my_encoding = string_encoding
+          def self.encoding
+            @my_encoding
+          end
+        end
+      end
+
+      io
     end
 
     class << self

--- a/lib/ruby-debug-ide/commands/expression_info.rb
+++ b/lib/ruby-debug-ide/commands/expression_info.rb
@@ -9,13 +9,20 @@ module Debugger
     end
 
     def execute
-      string_to_parse = unescape_incoming(@match.post_match) + "\n\n\n"
+      string_to_parse = Command.unescape_incoming(@match.post_match) + "\n\n\n"
       total_lines = string_to_parse.count("\n") + 1
 
       lexer = RubyLex.new
       io = StringIO.new(string_to_parse)
+
+      begin
+        encoding = string_to_parse.encoding
+      rescue
+        encoding = 'None'
+      end
+
       # for passing to the lexer
-      io.instance_exec(string_to_parse.encoding) do |string_encoding|
+      io.instance_exec(encoding) do |string_encoding|
         @my_encoding = string_encoding
         def self.encoding
           @my_encoding
@@ -39,7 +46,7 @@ module Debugger
       end
 
       incomplete = true
-      if /\A\s*\Z/m =~ last_statement[0]
+      if /\A\s*\Z/m =~ last_statement
         incomplete = false
       end
 

--- a/lib/ruby-debug-ide/version.rb
+++ b/lib/ruby-debug-ide/version.rb
@@ -1,3 +1,3 @@
 module Debugger
-  IDE_VERSION='0.4.27'
+  IDE_VERSION='0.4.28'
 end

--- a/test-base/expression_info_test.rb
+++ b/test-base/expression_info_test.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+$:.unshift File.join(File.dirname(__FILE__), "..", "lib")
+
+require 'test_base'
+
+module ExpressionInfoTest
+
+  def test_info_multiline_expression
+    create_socket ["sleep 0.1"]
+    run_to_line(1)
+    send_ruby('expression_info 1+')
+    expression_info = read_expression_info
+    assert_equal("true", expression_info.incomplete)
+
+    send_ruby('expression_info 1+\\n1')
+    expression_info = read_expression_info
+    assert_equal("false", expression_info.incomplete)
+
+    send_ruby('expression_info "')
+    expression_info = read_expression_info
+    assert_equal("true", expression_info.incomplete)
+
+    send_ruby('expression_info "\\\\"')
+    expression_info = read_expression_info
+    assert_equal("true", expression_info.incomplete)
+
+    send_ruby('expression_info "\\\\\\n"')
+    expression_info = read_expression_info
+    assert_equal("false", expression_info.incomplete)
+
+    send_ruby('expression_info def my_meth')
+    expression_info = read_expression_info
+    assert_equal("true", expression_info.incomplete)
+    send_cont
+  end
+
+end
+

--- a/test-base/inspect_test.rb
+++ b/test-base/inspect_test.rb
@@ -68,24 +68,31 @@ module InspectTest
     send_cont
   end
 
-  def test_inspect_escaping_escaped_newlines
+  def test_inspect_unescaping_escaped_newlines
     create_socket ["sleep 0.1"]
     run_to_line(1)
 
     send_ruby('v inspect "\\\\n".size')
-    variable = read_variables
+    variables = read_variables
     assert_equal(1, variables.length, "There is one variable returned.")
-    assert_equal(1, variables[0].value, "There is one char (newline)")
+    assert_equal("1", variables[0].value, "There is one char (newline)")
 
     send_ruby('v inspect "\\\\\\n".size')
-    variable = read_variables
+    variables = read_variables
     assert_equal(1, variables.length, "There is one variable returned.")
-    assert_equal(0, variables[0].value, "There are no chars, it's line continuation here")
+    assert_equal("0", variables[0].value, "There are no chars, it's line continuation here")
 
     send_ruby('v inspect "\\\\\\\\\\n".size')
-    variable = read_variables
+    variables = read_variables
     assert_equal(1, variables.length, "There is one variable returned.")
-    assert_equal(2, variables[0].value, "There are two chars: escaped backslash and newline")
+    assert_equal("2", variables[0].value, "There are two chars: escaped backslash and newline")
+
+    send_ruby('v inspect \'"\\\\n\'.size')
+    variables = read_variables
+    assert_equal(1, variables.length, "There is one variable returned.")
+    assert_equal("3", variables[0].value, "There are three chars: quote, backslash and n")
+
+    send_cont
   end
 
 end

--- a/test-base/inspect_test.rb
+++ b/test-base/inspect_test.rb
@@ -68,5 +68,25 @@ module InspectTest
     send_cont
   end
 
+  def test_inspect_escaping_escaped_newlines
+    create_socket ["sleep 0.1"]
+    run_to_line(1)
+
+    send_ruby('v inspect "\\\\n".size')
+    variable = read_variables
+    assert_equal(1, variables.length, "There is one variable returned.")
+    assert_equal(1, variables[0].value, "There is one char (newline)")
+
+    send_ruby('v inspect "\\\\\\n".size')
+    variable = read_variables
+    assert_equal(1, variables.length, "There is one variable returned.")
+    assert_equal(0, variables[0].value, "There are no chars, it's line continuation here")
+
+    send_ruby('v inspect "\\\\\\\\\\n".size')
+    variable = read_variables
+    assert_equal(1, variables.length, "There is one variable returned.")
+    assert_equal(2, variables[0].value, "There are two chars: escaped backslash and newline")
+  end
+
 end
 

--- a/test-base/readers.rb
+++ b/test-base/readers.rb
@@ -19,6 +19,7 @@ module Readers
   RubyThread = Struct.new("RubyThread", :id, :status)
   Frame = Struct.new("Frame", :no, :file, :line)
   Variable = Struct.new("Variable", :name, :kind, :value, :type, :hasChildren, :objectId)
+  ExpressionInfo = Struct.new("ExpressionInfo", :incomplete, :prompt, :indent)
 
   def read_breakpoint_added
     (@breakpoint_added_reader ||= BreakPointAddedReader.new(parser)).read
@@ -86,6 +87,10 @@ module Readers
 
   def read_processing_exception
     (@processing_exception_reader ||= ProcessingExceptionReader.new(parser)).read
+  end
+
+  def read_expression_info
+    (@expression_info_reader ||= ExpressionInfoReader.new(parser)).read
   end
 
   def parser
@@ -312,6 +317,13 @@ module Readers
     def read
       data = read_element_data('processingException')
       ProcessingException.new(data['type'], data['message'])
+    end
+  end
+
+  class ExpressionInfoReader < BaseReader
+    def read
+      data = read_element_data("expressionInfo")
+      ExpressionInfo.new(data['incomplete'], data['prompt'], data['indent'])
     end
   end
 

--- a/test/rd_expression_info_test.rb
+++ b/test/rd_expression_info_test.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require 'rd_test_base'
+require 'expression_info_test'
+
+class RDExpressionInfoTest < RDTestBase
+
+  include ExpressionInfoTest
+
+end
+

--- a/test/ruby-debug/unescape_incoming_test.rb
+++ b/test/ruby-debug/unescape_incoming_test.rb
@@ -1,0 +1,34 @@
+require 'test/unit'
+require 'ruby-debug-ide/command'
+
+class UnescaperTest < Test::Unit::TestCase
+
+  def test_empty
+    do_test('', '')
+    do_test('a', 'a')
+  end
+
+  def test_newline
+    do_test('\n', "\n")
+    do_test('a\n', "a\n")
+  end
+
+  def test_escaped_newline
+    do_test('\\\\n', '\n')
+    do_test('a\\\\n', 'a\n')
+  end
+
+  def test_backslash_and_newline
+    do_test('\\\\\\n', "\\\n")
+    do_test('a\\\\\\n', "a\\\n")
+  end
+
+  def test_something
+    do_test('hello\nthere\\\\n', "hello\nthere\\n")
+    do_test('"\\\\\\n".size', "\"\\\n\".size")
+  end
+
+  def do_test(input, expected_result)
+    assert_equal(expected_result, Debugger::Command.unescape_incoming(input))
+  end
+end


### PR DESCRIPTION
Currently there is no way to differ newline (`\n`) from escaped (`\\n`) since backslashes are not escaped. I propose to escape backslashes when querying ruby-debug-ide and expect these escapes while parsing input.