### PR TITLE
check for nil DEBUGGER_STORED_RUBYLIB before trying to split it

### DIFF
--- a/lib/ruby-debug-ide/multiprocess/starter.rb
+++ b/lib/ruby-debug-ide/multiprocess/starter.rb
@@ -1,8 +1,10 @@
 if ENV['IDE_PROCESS_DISPATCHER']
   require 'rubygems'
-  ENV['DEBUGGER_STORED_RUBYLIB'].split(File::PATH_SEPARATOR).each do |path|
-    next unless path =~ /ruby-debug-ide|ruby-debug-base|linecache|debase/
-    $LOAD_PATH << path
+  unless ENV['DEBUGGER_STORED_RUBYLIB'].nil?
+    ENV['DEBUGGER_STORED_RUBYLIB'].split(File::PATH_SEPARATOR).each do |path|
+      next unless path =~ /ruby-debug-ide|ruby-debug-base|linecache|debase/
+      $LOAD_PATH << path
+    end
   end
   require 'ruby-debug-ide'
   require 'ruby-debug-ide/multiprocess'


### PR DESCRIPTION
This avoids an unnecessary error if RUBYLIB isn't defined.
