### PR TITLE
exec monkey patch fix

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -117,6 +117,7 @@ if options.dispatcher_port != -1
   else
     require_relative '../lib/ruby-debug-ide/multiprocess'
   end
+  Debugger::MultiProcess.do_monkey
 
   ENV['DEBUGGER_STORED_RUBYLIB'] = ENV['RUBYLIB'] 
   old_opts = ENV['RUBYOPT'] || ''
@@ -139,8 +140,6 @@ Debugger.tracing = options.tracing
 Debugger.evaluation_timeout = options.evaluation_timeout
 Debugger.catchpoint_deleted_event = options.catchpoint_deleted_event || options.rm_protocol_extensions
 Debugger.value_as_nested_element = options.value_as_nested_element || options.rm_protocol_extensions
-
-Debugger.attached = true
 
 if options.attach_mode
   if Debugger::FRONT_END == "debase"

--- a/lib/ruby-debug-ide/commands/control.rb
+++ b/lib/ruby-debug-ide/commands/control.rb
@@ -136,9 +136,9 @@ module Debugger
     end
 
     def execute
-      Debugger.attached = false
       Debugger.stop
       Debugger.interface.close
+      Debugger::MultiProcess.undo_monkey
       Debugger.control_thread = nil
       Thread.current.exit #@control_thread is a current thread
     end

--- a/lib/ruby-debug-ide/multiprocess.rb
+++ b/lib/ruby-debug-ide/multiprocess.rb
@@ -1,7 +1,23 @@
-if RUBY_VERSION < "1.9"
+if RUBY_VERSION < '1.9'
   require 'ruby-debug-ide/multiprocess/pre_child'
-  require 'ruby-debug-ide/multiprocess/monkey'
 else
   require_relative 'multiprocess/pre_child'
-  require_relative 'multiprocess/monkey'
+end
+
+module Debugger
+  module MultiProcess
+    class << self
+      def do_monkey
+        load File.expand_path(File.dirname(__FILE__) + '/multiprocess/monkey.rb')
+      end
+
+      def undo_monkey
+        if ENV['IDE_PROCESS_DISPATCHER']
+          load File.expand_path(File.dirname(__FILE__) + '/multiprocess/unmonkey.rb')
+          ruby_opts = ENV['RUBYOPT'].split(' ')
+          ENV['RUBYOPT'] = ruby_opts.keep_if {|opt| !opt.end_with?('ruby-debug-ide/multiprocess/starter')}.join(' ')
+        end
+      end
+    end
+  end
 end

--- a/lib/ruby-debug-ide/multiprocess/pre_child.rb
+++ b/lib/ruby-debug-ide/multiprocess/pre_child.rb
@@ -2,8 +2,6 @@ module Debugger
   module MultiProcess
     class << self
       def pre_child(options = nil)
-        return unless Debugger.attached
-
         require 'socket'
         require 'ostruct'
 

--- a/lib/ruby-debug-ide/multiprocess/unmonkey.rb
+++ b/lib/ruby-debug-ide/multiprocess/unmonkey.rb
@@ -1,0 +1,31 @@
+module Debugger
+  module MultiProcess
+    def self.restore_fork
+      %Q{
+        alias fork pre_debugger_fork
+      }
+    end
+
+    def self.restore_exec
+      %Q{
+        alias exec pre_debugger_exec
+      }
+    end
+  end
+end
+
+module Kernel
+  class << self
+    module_eval Debugger::MultiProcess.restore_fork
+    module_eval Debugger::MultiProcess.restore_exec
+  end
+  module_eval Debugger::MultiProcess.restore_fork
+  module_eval Debugger::MultiProcess.restore_exec
+end
+
+module Process
+  class << self
+    module_eval Debugger::MultiProcess.restore_fork
+    module_eval Debugger::MultiProcess.restore_exec
+  end
+end


### PR DESCRIPTION
`exec` system call fixed -- when user called it debugger did not attached to the "new process". This should fix this issue: https://youtrack.jetbrains.com/issue/RUBY-18865