### PR TITLE
inspect memory limit fix

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -38,14 +38,10 @@ EOB
   opts.separator "Options:"
   
   ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
-  opts.on("-m", "--memory-limit LIMIT", "evaluation memory limit in mb (default: 10)") do |limit| 
+  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit| 
     ENV['DEBUGGER_MEMORY_LIMIT'] = limit
   end
   
-  ENV['DEBUGGER_MEMORY_LIMIT_DISABLED'] = 'false'
-  opts.on("--memory-limit-disable", "disables the memory check") {ENV['DEBUGGER_MEMORY_LIMIT_DISABLED'] = 'true'}
-
-
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}
   opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}  
   opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -37,8 +37,8 @@ EOB
   opts.separator ""
   opts.separator "Options:"
   
-  ENV['DEBUGGER_MEMORY_LIMIT'] = '1'
-  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 1)") do |limit| 
+  ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
+  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit| 
     ENV['DEBUGGER_MEMORY_LIMIT'] = limit
   end
   

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -37,8 +37,8 @@ EOB
   opts.separator ""
   opts.separator "Options:"
   
-  ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
-  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit| 
+  ENV['DEBUGGER_MEMORY_LIMIT'] = '1'
+  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 1)") do |limit| 
     ENV['DEBUGGER_MEMORY_LIMIT'] = limit
   end
   

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -42,6 +42,10 @@ EOB
     ENV['DEBUGGER_MEMORY_LIMIT'] = limit
   end
   
+  ENV['DEBUGGER_MEMORY_LIMIT_DISABLED'] = 'false'
+  opts.on("--memory-limit-disable", "disables the memory check") {ENV['DEBUGGER_MEMORY_LIMIT_DISABLED'] = 'true'}
+
+
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}
   opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}  
   opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -51,7 +51,6 @@ EOB
     options.evaluation_timeout = timeout
   end
   opts.on('--stop', 'stop when the script is loaded') {options.stop = true}
-  
   opts.on("-x", "--trace", "turn on line tracing") {options.tracing = true}
   opts.on("-l", "--load-mode", "load mode (experimental)") {options.load_mode = true}
   opts.on("-d", "--debug", "Debug self - prints information for debugging ruby-debug itself") do

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -42,6 +42,11 @@ EOB
     ENV['DEBUGGER_MEMORY_LIMIT'] = limit
   end
   
+  ENV['INSPECT_TIME_LIMIT'] = '100'
+  opts.on("-t", "--time-limit LIMIT", Integer, "evaluation time limit in milliseconds (default: 100)") do |limit| 
+    ENV['INSPECT_TIME_LIMIT'] = limit
+  end
+
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}
   opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}  
   opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -36,6 +36,12 @@ Usage: rdebug-ide is supposed to be called from RDT, NetBeans, RubyMine, or
 EOB
   opts.separator ""
   opts.separator "Options:"
+  
+  ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
+  opts.on("-m", "--memory-limit LIMIT", "evaluation memory limit in mb (default: 10)") do |limit| 
+    ENV['DEBUGGER_MEMORY_LIMIT'] = limit
+  end
+  
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}
   opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}  
   opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 
@@ -45,6 +51,7 @@ EOB
     options.evaluation_timeout = timeout
   end
   opts.on('--stop', 'stop when the script is loaded') {options.stop = true}
+  
   opts.on("-x", "--trace", "turn on line tracing") {options.tracing = true}
   opts.on("-l", "--load-mode", "load mode (experimental)") {options.load_mode = true}
   opts.on("-d", "--debug", "Debug self - prints information for debugging ruby-debug itself") do

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -397,19 +397,21 @@ module Debugger
 
         trace = TracePoint.new(:c_call, :call) do |tp|
           
-          curr_alloc_size = ObjectSpace.memsize_of_all
-          curr_time = Time.now
-          
-          if(curr_time - start_time > max_time) 
-            curr_thread.raise TimeLimitError, "Timeout: evaluation of inspect took longer than #{max_time}sec. \n#{caller.map{|l| "\t#{l}"}.join("\n")}"
-            trace.disable
-          end
+          if(rand > 0.75) 
+            curr_alloc_size = ObjectSpace.memsize_of_all
+            curr_time = Time.now
+            
+            if(curr_time - start_time > max_time) 
+              curr_thread.raise TimeLimitError, "Timeout: evaluation of inspect took longer than #{max_time}sec. \n#{caller.map{|l| "\t#{l}"}.join("\n")}"
+              trace.disable
+            end
 
-          start_alloc_size = curr_alloc_size if (curr_alloc_size < start_alloc_size)
-          
-          if(curr_alloc_size - start_alloc_size > 1e6 * memory_limit)
-            curr_thread.raise MemoryLimitError, "Out of memory: evaluation of inspect took more than #{memory_limit}mb. \n#{caller.map{|l| "\t#{l}"}.join("\n")}"
-            trace.disable
+            start_alloc_size = curr_alloc_size if (curr_alloc_size < start_alloc_size)
+            
+            if(curr_alloc_size - start_alloc_size > 1e6 * memory_limit)
+              curr_thread.raise MemoryLimitError, "Out of memory: evaluation of inspect took more than #{memory_limit}mb. \n#{caller.map{|l| "\t#{l}"}.join("\n")}"
+              trace.disable
+            end
           end
         end.enable {
           result = slice.inspect

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -384,7 +384,7 @@ module Debugger
       50
     end
 
-    def inspect_with_allocation_control(slice, memory_limit, obj_id)
+    def inspect_with_allocation_control(slice, memory_limit)
       curr_thread = Thread.current
       
       start_alloc_size = ObjectSpace.memsize_of_all
@@ -395,7 +395,7 @@ module Debugger
         if(curr_alloc_size - start_alloc_size > 1e6 * memory_limit)
           
           trace.disable
-          curr_thread.raise MemoryLimitError, "Out of memory: evaluation of inspect for obj(#{obj_id}) took more than #{memory_limit}mb." if curr_thread.alive?
+          curr_thread.raise MemoryLimitError, "Out of memory: evaluation of inspect took more than #{memory_limit}mb." if curr_thread.alive?
         end
       end
 
@@ -414,7 +414,7 @@ module Debugger
       compact = if (defined?(JRUBY_VERSION) || ENV['DEBUGGER_MEMORY_LIMIT'].to_i <= 0)
                   slice.inspect
                 else  
-                  compact = inspect_with_allocation_control(slice, ENV['DEBUGGER_MEMORY_LIMIT'].to_i, value.object_id.to_s)
+                  compact = inspect_with_allocation_control(slice, ENV['DEBUGGER_MEMORY_LIMIT'].to_i)
                 end 
       
       if compact && value.size != slice.size

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -409,7 +409,7 @@ module Debugger
     def compact_array_str(value)
       slice   = value[0..10]
       
-      if defined?(JRUBY_VERSION)
+      if (defined?(JRUBY_VERSION) || ENV['DEBUGGER_MEMORY_LIMIT_DISABLED'] == 'true')
         compact = slice.inspect
       else  
         compact = inspect_with_allocation_control(slice, ENV['DEBUGGER_MEMORY_LIMIT'].to_i)

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -9,7 +9,7 @@ module Debugger
     attr_reader :message
     attr_reader :backtrace
 
-    def initialize(message, backtrace)
+    def initialize(message, backtrace = '')
       @message = message
       @backtrace = backtrace
     end
@@ -159,7 +159,7 @@ module Debugger
       end
     end
 
-    def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, flag)
+    def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, return_message_if_overflow)
       curr_thread = Thread.current
       result = nil
       inspect_thread = DebugThread.start {
@@ -194,8 +194,7 @@ module Debugger
     rescue MemoryLimitError, TimeLimitError => e
       print_debug(e.message + "\n" + e.backtrace)
       
-      return nil if flag
-      return e.message
+      return return_message_if_overflow ? e.message : nil
     end
 
     def print_variable(name, value, kind)

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -431,7 +431,7 @@ module Debugger
       compact = if (defined?(JRUBY_VERSION) || ENV['DEBUGGER_MEMORY_LIMIT'].to_i <= 0)
                   slice.inspect
                 else  
-                  compact = inspect_with_allocation_control(slice, ENV['DEBUGGER_MEMORY_LIMIT'].to_i)
+                  inspect_with_allocation_control(slice, ENV['DEBUGGER_MEMORY_LIMIT'].to_i)
                 end 
       
       if compact && value.size != slice.size

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -404,7 +404,7 @@ module Debugger
       trace.disable
       result 
     rescue MemoryLimitError => e
-      print_msg(e.message)
+      print_debug(e.message)
       return nil
     end 
 

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -404,8 +404,7 @@ module Debugger
       trace.disable 
     rescue MemoryLimitError
       return nil
-    end
-    
+    end 
 
     def compact_array_str(value)
       slice   = value[0..10]
@@ -421,7 +420,6 @@ module Debugger
       end
       compact
     end
-
 
     def compact_hash_str(value)
       slice   = value.sort_by { |k, _| k.to_s }[0..5]

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -45,7 +45,6 @@ module Debugger
     end
     
     def print_msg(*args)
-      puts 'def print_msg(*args)'
       msg, *args = args
       xml_message = CGI.escapeHTML(msg % args)
       print "<message>#{xml_message}</message>"

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -409,7 +409,7 @@ module Debugger
     def compact_array_str(value)
       slice   = value[0..10]
       
-      if (defined?(JRUBY_VERSION) || ENV['DEBUGGER_MEMORY_LIMIT_DISABLED'] == 'true')
+      if (defined?(JRUBY_VERSION) || ENV['DEBUGGER_MEMORY_LIMIT'].to_i <= 0)
         compact = slice.inspect
       else  
         compact = inspect_with_allocation_control(slice, ENV['DEBUGGER_MEMORY_LIMIT'].to_i)

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -395,7 +395,7 @@ module Debugger
         if(curr_alloc_size - start_alloc_size > 1e6 * memory_limit)
           
           trace.disable
-          curr_thread.raise MemoryLimitError, "Out of memory: evaluation took longer than 10mb." if curr_thread.alive?
+          curr_thread.raise MemoryLimitError, "Out of memory: evaluation took longer than #{memory_limit}mb." if curr_thread.alive?
         end
       end
 


### PR DESCRIPTION
Sets a memory limit for execution of inspect (default 10mb)