### PR TITLE
zeus deadlock fix

### DIFF
--- a/lib/ruby-debug-ide/multiprocess/starter.rb
+++ b/lib/ruby-debug-ide/multiprocess/starter.rb
@@ -6,5 +6,6 @@ if ENV['IDE_PROCESS_DISPATCHER']
   end
   require 'ruby-debug-ide'
   require 'ruby-debug-ide/multiprocess'
+  Debugger::MultiProcess::do_monkey
   Debugger::MultiProcess::pre_child
 end


### PR DESCRIPTION
Must set the 'fork' and 'exec' aliases for child processes