### PR TITLE
Create alias for Timeout.timeout during eval execution

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -8,23 +8,23 @@ else
   require_relative '../lib/ruby-debug-ide'
 end
 
-$stdout.sync=true
+$stdout.sync = true
 
 options = OpenStruct.new(
-  'frame_bind'  => false,
-  'host'        => nil,
-  'load_mode'   => false,
-  'port'        => 1234,
-  'stop'        => false,
-  'tracing'     => false,
-  'int_handler' => true,
-  'dispatcher_port' => -1,
-  'evaluation_timeout' => 10,
-  'rm_protocol_extensions' => false,
-  'catchpoint_deleted_event' => false,
-  'value_as_nested_element' => false,
-  'attach_mode' => false,
-  'cli_debug' => false
+    'frame_bind' => false,
+    'host' => nil,
+    'load_mode' => false,
+    'port' => 1234,
+    'stop' => false,
+    'tracing' => false,
+    'int_handler' => true,
+    'dispatcher_port' => -1,
+    'evaluation_timeout' => 10,
+    'rm_protocol_extensions' => false,
+    'catchpoint_deleted_event' => false,
+    'value_as_nested_element' => false,
+    'attach_mode' => false,
+    'cli_debug' => false
 )
 
 opts = OptionParser.new do |opts|
@@ -36,23 +36,23 @@ Usage: rdebug-ide is supposed to be called from RDT, NetBeans, RubyMine, or
 EOB
   opts.separator ""
   opts.separator "Options:"
-  
+
   ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
-  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit| 
+  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit|
     ENV['DEBUGGER_MEMORY_LIMIT'] = limit
   end
-  
+
   ENV['INSPECT_TIME_LIMIT'] = '100'
-  opts.on("-t", "--time-limit LIMIT", Integer, "evaluation time limit in milliseconds (default: 100)") do |limit| 
+  opts.on("-t", "--time-limit LIMIT", Integer, "evaluation time limit in milliseconds (default: 100)") do |limit|
     ENV['INSPECT_TIME_LIMIT'] = limit
   end
 
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}
-  opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}  
-  opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 
+  opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}
+  opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp|
     options.dispatcher_port = dp
   end
-  opts.on('--evaluation-timeout TIMEOUT', Integer,'evaluation timeout in seconds (default: 10)') do |timeout|
+  opts.on('--evaluation-timeout TIMEOUT', Integer, 'evaluation timeout in seconds (default: 10)') do |timeout|
     options.evaluation_timeout = timeout
   end
   opts.on('--stop', 'stop when the script is loaded') {options.stop = true}
@@ -130,7 +130,7 @@ if options.dispatcher_port != -1
   end
   Debugger::MultiProcess.do_monkey
 
-  ENV['DEBUGGER_STORED_RUBYLIB'] = ENV['RUBYLIB'] 
+  ENV['DEBUGGER_STORED_RUBYLIB'] = ENV['RUBYLIB']
   old_opts = ENV['RUBYOPT'] || ''
   starter = "-r#{File.expand_path(File.dirname(__FILE__))}/../lib/ruby-debug-ide/multiprocess/starter"
   unless old_opts.include? starter
@@ -142,7 +142,7 @@ end
 
 if options.int_handler
   # install interruption handler
-  trap('INT') { Debugger.interrupt_last }
+  trap('INT') {Debugger.interrupt_last}
 end
 
 # set options

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -119,6 +119,14 @@ else
   Debugger::PROG_SCRIPT = $0
 end
 
+if RUBY_VERSION < "1.9"
+   lib_path = File.expand_path(File.dirname(__FILE__) + "/../lib/")
+   $: << lib_path unless $:.include? lib_path
+   require 'ruby-debug-ide/timeout_monkeypatch'
+else
+  require_relative '../lib/ruby-debug-ide/timeout_monkeypatch'
+end
+
 if options.dispatcher_port != -1
   ENV['IDE_PROCESS_DISPATCHER'] = options.dispatcher_port.to_s
   if RUBY_VERSION < "1.9"

--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -121,9 +121,18 @@ module Debugger
         to_inspect = Command.unescape_incoming(str)
         max_time = Debugger.evaluation_timeout
         @printer.print_debug("Evaluating %s with timeout after %i sec", str, max_time)
+
+        Debugger::TimeoutHandler.do_timeout_monkey
+
+        eval_result = nil
+
         timeout(max_time) do
-          eval(to_inspect, b)
+          eval_result = eval(to_inspect, b)
         end
+
+        Debugger::TimeoutHandler.undo_timeout_monkey
+
+        return eval_result
       rescue StandardError, ScriptError => e
         @printer.print_exception(e, @state.binding)
         throw :debug_error

--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -4,8 +4,7 @@ require 'delegate'
 module Debugger
 
   class Command < SimpleDelegator # :nodoc:
-    SubcmdStruct=Struct.new(:name, :min, :short_help, :long_help) unless
-      defined?(SubcmdStruct)
+    SubcmdStruct = Struct.new(:name, :min, :short_help, :long_help) unless defined?(SubcmdStruct)
 
     # Find param in subcmds. param id downcased and can be abbreviated
     # to the minimum length listed in the subcommands
@@ -13,7 +12,7 @@ module Debugger
       param.downcase!
       for try_subcmd in subcmds do
         if (param.size >= try_subcmd.min) and
-            (try_subcmd.name[0..param.size-1] == param)
+            (try_subcmd.name[0..param.size - 1] == param)
           return try_subcmd
         end
       end
@@ -24,31 +23,31 @@ module Debugger
       def commands
         @commands ||= []
       end
-      
+
       DEF_OPTIONS = {
-        :event => true, 
-        :control => false, 
-        :unknown => false,
-        :need_context => false,
+          :event => true,
+          :control => false,
+          :unknown => false,
+          :need_context => false,
       }
-      
+
       def inherited(klass)
         DEF_OPTIONS.each do |o, v|
           klass.options[o] = v if klass.options[o].nil?
         end
         commands << klass
-      end 
+      end
 
       def load_commands
         dir = File.dirname(__FILE__)
         Dir[File.join(dir, 'commands', '*')].each do |file|
           require file if file =~ /\.rb$/
         end
-        Debugger.constants.grep(/Functions$/).map { |name| Debugger.const_get(name) }.each do |mod|
+        Debugger.constants.grep(/Functions$/).map {|name| Debugger.const_get(name)}.each do |mod|
           include mod
         end
       end
-      
+
       def method_missing(meth, *args, &block)
         if meth.to_s =~ /^(.+?)=$/
           @options[$1.intern] = args.first
@@ -60,7 +59,7 @@ module Debugger
           end
         end
       end
-      
+
       def options
         @options ||= {}
       end
@@ -75,12 +74,12 @@ module Debugger
         defined?(Debugger.file_filter)
       end
     end
-    
+
     def initialize(state, printer)
       @state, @printer = state, printer
       super @printer
     end
-    
+
     def match(input)
       @match = regexp.match(input)
     end
@@ -101,7 +100,7 @@ module Debugger
     def timeout(sec)
       return yield if sec == nil or sec.zero?
       if Thread.respond_to?(:critical) and Thread.critical
-        raise ThreadError, "timeout within critical session"      
+        raise ThreadError, "timeout within critical session"
       end
       begin
         x = Thread.current
@@ -118,7 +117,7 @@ module Debugger
     def debug_eval(str, b = get_binding)
       begin
         str = str.to_s
-        str.force_encoding('UTF-8') if(RUBY_VERSION > '2.0')
+        str.force_encoding('UTF-8') if (RUBY_VERSION > '2.0')
         to_inspect = Command.unescape_incoming(str)
         max_time = Debugger.evaluation_timeout
         @printer.print_debug("Evaluating %s with timeout after %i sec", str, max_time)
@@ -126,7 +125,7 @@ module Debugger
           eval(to_inspect, b)
         end
       rescue StandardError, ScriptError => e
-        @printer.print_exception(e, @state.binding) 
+        @printer.print_exception(e, @state.binding)
         throw :debug_error
       end
     end
@@ -139,7 +138,7 @@ module Debugger
         nil
       end
     end
-    
+
     def get_binding
       @state.context.frame_binding(@state.frame_pos)
     end
@@ -149,7 +148,7 @@ module Debugger
     end
 
     def get_context(thnum)
-      Debugger.contexts.find{|c| c.thnum == thnum}
+      Debugger.contexts.find {|c| c.thnum == thnum}
     end
 
     def realpath(filename)
@@ -166,6 +165,6 @@ module Debugger
       end
     end
   end
-  
+
   Command.load_commands
 end

--- a/lib/ruby-debug-ide/timeout-patch/monkey_timeout.rb
+++ b/lib/ruby-debug-ide/timeout-patch/monkey_timeout.rb
@@ -1,57 +1,49 @@
-module Debugger
-  module TimeoutHandler
-    def self.create_mp_timeout
-      %q{
-        alias pre_eval_timeout timeout
-
-        def timeout(sec, klass = nil)   #:yield: +sec+
-          return yield(sec) if sec == nil or sec.zero?
-          message = "execution expired".freeze
-          from = "from #{caller_locations(1, 1)[0]}" if $DEBUG
-          e = Error
-          bl = proc do |exception|
-            begin
-              x = Thread.current
-              y = Debugger::DebugThread.start {
-                Thread.current.name = from
-                begin
-                  sleep sec
-                rescue => e
-                  x.raise e
-                else
-                  x.raise exception, message
-                end
-              }
-              return yield(sec)
-            ensure
-              if y
-                y.kill
-                y.join # make sure y is dead.
-              end
-            end
-          end
-          if klass
-            begin
-              bl.call(klass)
-            rescue klass => e
-              bt = e.backtrace
-            end
-          else
-            bt = Error.catch(message, &bl)
-          end
-          level = -caller(CALLER_OFFSET).size-2
-          while THIS_FILE =~ bt[level]
-            bt.delete_at(level)
-          end
-          raise(e, message, bt)
-        end
-      }
-    end
-  end
-end
-
 module Timeout
   class << self
-    module_eval Debugger::TimeoutHandler.create_mp_timeout
+    module_eval {
+      alias pre_eval_timeout timeout
+
+      def timeout(sec, klass = nil) #:yield: +sec+
+        return yield(sec) if sec == nil or sec.zero?
+        message = "execution expired".freeze
+        from = "from #{caller_locations(1, 1)[0]}" if $DEBUG
+        e = Error
+        bl = proc do |exception|
+          begin
+            x = Thread.current
+            y = Debugger::DebugThread.start {
+              Thread.current.name = from
+              begin
+                sleep sec
+              rescue => e
+                x.raise e
+              else
+                x.raise exception, message
+              end
+            }
+            return yield(sec)
+          ensure
+            if y
+              y.kill
+              y.join # make sure y is dead.
+            end
+          end
+        end
+        if klass
+          begin
+            bl.call(klass)
+          rescue klass => e
+            bt = e.backtrace
+          end
+        else
+          bt = Error.catch(message, &bl)
+        end
+        level = -caller(CALLER_OFFSET).size - 2
+        while THIS_FILE =~ bt[level]
+          bt.delete_at(level)
+        end
+        raise(e, message, bt)
+      end
+    }
   end
 end

--- a/lib/ruby-debug-ide/timeout-patch/monkey_timeout.rb
+++ b/lib/ruby-debug-ide/timeout-patch/monkey_timeout.rb
@@ -1,0 +1,57 @@
+module Debugger
+  module TimeoutHandler
+    def self.create_mp_timeout
+      %q{
+        alias pre_eval_timeout timeout
+
+        def timeout(sec, klass = nil)   #:yield: +sec+
+          return yield(sec) if sec == nil or sec.zero?
+          message = "execution expired".freeze
+          from = "from #{caller_locations(1, 1)[0]}" if $DEBUG
+          e = Error
+          bl = proc do |exception|
+            begin
+              x = Thread.current
+              y = Debugger::DebugThread.start {
+                Thread.current.name = from
+                begin
+                  sleep sec
+                rescue => e
+                  x.raise e
+                else
+                  x.raise exception, message
+                end
+              }
+              return yield(sec)
+            ensure
+              if y
+                y.kill
+                y.join # make sure y is dead.
+              end
+            end
+          end
+          if klass
+            begin
+              bl.call(klass)
+            rescue klass => e
+              bt = e.backtrace
+            end
+          else
+            bt = Error.catch(message, &bl)
+          end
+          level = -caller(CALLER_OFFSET).size-2
+          while THIS_FILE =~ bt[level]
+            bt.delete_at(level)
+          end
+          raise(e, message, bt)
+        end
+      }
+    end
+  end
+end
+
+module Timeout
+  class << self
+    module_eval Debugger::TimeoutHandler.create_mp_timeout
+  end
+end

--- a/lib/ruby-debug-ide/timeout-patch/unmonkey_timeout.rb
+++ b/lib/ruby-debug-ide/timeout-patch/unmonkey_timeout.rb
@@ -1,0 +1,13 @@
+module Debugger
+  module TimeoutHandler
+    class << self
+      def do_timeout_monkey
+        load File.expand_path(File.dirname(__FILE__) + '/timeout-patch/monkey_timeout.rb')
+      end
+
+      def undo_timeout_monkey
+        load File.expand_path(File.dirname(__FILE__) + '/timeout-patch/unmonkey_timeout.rb')
+      end
+    end
+  end
+end

--- a/lib/ruby-debug-ide/timeout-patch/unmonkey_timeout.rb
+++ b/lib/ruby-debug-ide/timeout-patch/unmonkey_timeout.rb
@@ -1,13 +1,7 @@
-module Debugger
-  module TimeoutHandler
-    class << self
-      def do_timeout_monkey
-        load File.expand_path(File.dirname(__FILE__) + '/timeout-patch/monkey_timeout.rb')
-      end
-
-      def undo_timeout_monkey
-        load File.expand_path(File.dirname(__FILE__) + '/timeout-patch/unmonkey_timeout.rb')
-      end
-    end
+module Timeout
+  class << self
+    module_eval {
+      alias timeout pre_eval_timeout
+    }
   end
 end

--- a/lib/ruby-debug-ide/timeout_monkeypatch.rb
+++ b/lib/ruby-debug-ide/timeout_monkeypatch.rb
@@ -1,0 +1,13 @@
+module Debugger
+  module TimeoutHandler
+    class << self
+      def do_timeout_monkey
+        load File.expand_path(File.dirname(__FILE__) + '/timeout-patch/monkey_timeout.rb')
+      end
+
+      def undo_timeout_monkey
+        load File.expand_path(File.dirname(__FILE__) + '/timeout-patch/unmonkey_timeout.rb')
+      end
+    end
+  end
+end


### PR DESCRIPTION
While the debugger is on the breakpoint all threads are stopped. Therefore, the new thread, which is spawned by the timeout, is also stopped. So we replace the timeout with our timeout, which use DebugThreads instead of regular Threads.
https://youtrack.jetbrains.com/issue/RUBY-17930