### PR TITLE
set evaluation timeout for child processes

### DIFF
--- a/lib/ruby-debug-ide/multiprocess/pre_child.rb
+++ b/lib/ruby-debug-ide/multiprocess/pre_child.rb
@@ -16,7 +16,8 @@ module Debugger
             'tracing'     => false,
             'int_handler' => true,
             'cli_debug'   => (ENV['DEBUGGER_CLI_DEBUG'] == 'true'),
-            'notify_dispatcher' => true
+            'notify_dispatcher' => true,
+            'evaluation_timeout' => 10
         )
 
         if(options.ignore_port)
@@ -43,6 +44,7 @@ module Debugger
         # set options
         Debugger.keep_frame_binding = options.frame_bind
         Debugger.tracing = options.tracing
+        Debugger.evaluation_timeout = options.evaluation_timeout
         Debugger.cli_debug = options.cli_debug
         Debugger.prepare_debugger(options)
       end


### PR DESCRIPTION
For child processes, there was no evaluation timeout. In particular, because of this, when you try to eval something in a subprocess, the following exception is raised: `can not convert nil into Integer`.
`@printer.print_debug("Evaluating %s with timeout after %i sec", str, max_time(which is nil))`
(https://youtrack.jetbrains.com/issue/RUBY-19948)