### PR TITLE
Implementation of exec_with_allocation_control without exceptions

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -37,7 +37,7 @@ EOB
   opts.separator ""
   opts.separator "Options:"
 
-  Debugger.trace_to_s = true
+  Debugger.trace_to_s = false
   opts.on("--evaluation-control", "trace to_s evaluation") do
     Debugger.trace_to_s = true
   end

--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -11,20 +11,20 @@ end
 $stdout.sync=true
 
 options = OpenStruct.new(
-  'frame_bind'  => false,
-  'host'        => nil,
-  'load_mode'   => false,
-  'port'        => 1234,
-  'stop'        => false,
-  'tracing'     => false,
-  'int_handler' => true,
-  'dispatcher_port' => -1,
-  'evaluation_timeout' => 10,
-  'rm_protocol_extensions' => false,
-  'catchpoint_deleted_event' => false,
-  'value_as_nested_element' => false,
-  'attach_mode' => false,
-  'cli_debug' => false
+    'frame_bind'  => false,
+    'host'        => nil,
+    'load_mode'   => false,
+    'port'        => 1234,
+    'stop'        => false,
+    'tracing'     => false,
+    'int_handler' => true,
+    'dispatcher_port' => -1,
+    'evaluation_timeout' => 10,
+    'rm_protocol_extensions' => false,
+    'catchpoint_deleted_event' => false,
+    'value_as_nested_element' => false,
+    'attach_mode' => false,
+    'cli_debug' => false
 )
 
 opts = OptionParser.new do |opts|
@@ -36,20 +36,25 @@ Usage: rdebug-ide is supposed to be called from RDT, NetBeans, RubyMine, or
 EOB
   opts.separator ""
   opts.separator "Options:"
-  
-  ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
-  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit| 
-    ENV['DEBUGGER_MEMORY_LIMIT'] = limit
+
+  Debugger.trace_to_s = true
+  opts.on("--evaluation-control", "trace to_s evaluation") do
+    Debugger.trace_to_s = true
   end
-  
+
+  ENV['DEBUGGER_MEMORY_LIMIT'] = '10'
+  opts.on("-m", "--memory-limit LIMIT", Integer, "evaluation memory limit in mb (default: 10)") do |limit|
+    ENV['DEBUGGER_MEMORY_LIMIT'] = limit.to_s
+  end
+
   ENV['INSPECT_TIME_LIMIT'] = '100'
-  opts.on("-t", "--time-limit LIMIT", Integer, "evaluation time limit in milliseconds (default: 100)") do |limit| 
-    ENV['INSPECT_TIME_LIMIT'] = limit
+  opts.on("-t", "--time-limit LIMIT", Integer, "evaluation time limit in milliseconds (default: 100)") do |limit|
+    ENV['INSPECT_TIME_LIMIT'] = limit.to_s
   end
 
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}
   opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") {|port| options.port = port}
-  opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp| 
+  opts.on("--dispatcher-port PORT", Integer, "Port used for multi-process debugging dispatcher") do |dp|
     options.dispatcher_port = dp
   end
   opts.on('--evaluation-timeout TIMEOUT', Integer,'evaluation timeout in seconds (default: 10)') do |timeout|
@@ -133,7 +138,7 @@ if options.dispatcher_port != -1
   end
   Debugger::MultiProcess.do_monkey
 
-  ENV['DEBUGGER_STORED_RUBYLIB'] = ENV['RUBYLIB'] 
+  ENV['DEBUGGER_STORED_RUBYLIB'] = ENV['RUBYLIB']
   old_opts = ENV['RUBYOPT'] || ''
   starter = "-r#{File.expand_path(File.dirname(__FILE__))}/../lib/ruby-debug-ide/multiprocess/starter"
   unless old_opts.include? starter

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -29,22 +29,22 @@ module Debugger
     end
 
     def cleanup_backtrace(backtrace)
-       cleared = []
-       return cleared unless backtrace
-       backtrace.each do |line|
-         if line.index(File.expand_path(File.dirname(__FILE__) + "/..")) == 0
-           next
-         end
-         if line.index("-e:1") == 0
-           break
-         end
-         cleared << line
-       end
-       cleared
+      cleared = []
+      return cleared unless backtrace
+      backtrace.each do |line|
+        if line.index(File.expand_path(File.dirname(__FILE__) + "/..")) == 0
+          next
+        end
+        if line.index("-e:1") == 0
+          break
+        end
+        cleared << line
+      end
+      cleared
     end
 
     attr_accessor :attached
-    attr_accessor :cli_debug, :xml_debug, :evaluation_timeout
+    attr_accessor :cli_debug, :xml_debug, :evaluation_timeout, :trace_to_s
     attr_accessor :control_thread
     attr_reader :interface
     # protocol extensions

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -190,7 +190,7 @@ module Debugger
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
       return exec_with_timeout(time_limit * 1e-3) {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0' && time_limit > 0)
-      return value.send exec_method if RUBY_VERSION < '2.0'
+      return value.send exec_method if !Debugger.trace_to_s
 
       curr_thread = Thread.current
       control_thread = Debugger.control_thread

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -191,7 +191,7 @@ module Debugger
     end
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
-      return jruby_timeout(time_limit/1e3) {value.send exec_method} if defined?(JRUBY_VERSION)
+      return jruby_timeout(time_limit / 1e3) {value.send exec_method} if defined?(JRUBY_VERSION)
       return value.send exec_method if RUBY_VERSION < '2.0'
 
       curr_thread = Thread.current

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -15,17 +15,15 @@ module Debugger
 
   class ExecError < StandardError
     attr_reader :message
-    attr_reader :trace_point
     attr_reader :backtrace
 
-    def initialize(message, trace_point, backtrace = [])
+    def initialize(message, backtrace = [])
       @message = message
-      @trace_point = trace_point
       @backtrace = backtrace
     end
   end
 
-  class JrubyTimeLimitError < StandardError
+  class SimpleTimeLimitError < StandardError
     attr_reader :message
 
     def initialize(message)
@@ -173,7 +171,7 @@ module Debugger
       end
     end
 
-    def jruby_timeout(sec)
+    def exec_with_timeout(sec)
       return yield if sec == nil or sec.zero?
       if Thread.respond_to?(:critical) and Thread.critical
         raise ThreadError, "timeout within critical session"
@@ -182,7 +180,7 @@ module Debugger
         x = Thread.current
         y = DebugThread.start {
           sleep sec
-          x.raise JrubyTimeLimitError.new("Timeout: evaluation took longer than #{sec} seconds.") if x.alive?
+          x.raise SimpleTimeLimitError.new("Timeout: evaluation took longer than #{sec} seconds.") if x.alive?
         }
         yield sec
       ensure
@@ -191,48 +189,57 @@ module Debugger
     end
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
-      return jruby_timeout(time_limit / 1e3) {value.send exec_method} if defined?(JRUBY_VERSION)
+      return exec_with_timeout(time_limit * 1e-3) {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0' && time_limit > 0)
       return value.send exec_method if RUBY_VERSION < '2.0'
 
       curr_thread = Thread.current
+      control_thread = Debugger.control_thread
 
       result = nil
+
+      trace_queue = Queue.new
+
       inspect_thread = DebugThread.start do
-        start_alloc_size = ObjectSpace.memsize_of_all if check_memory_limit
+        start_alloc_size = ObjectSpace.memsize_of_all
         start_time = Time.now.to_f
 
-        trace_point = TracePoint.new(:c_call, :call) do | |
-          next unless Thread.current == inspect_thread
-          next unless rand > 0.75
-
+        trace_point = TracePoint.new(:c_call, :call) do |tp|
           curr_time = Time.now.to_f
 
           if (curr_time - start_time) * 1e3 > time_limit
-            curr_thread.raise TimeLimitError.new("Timeout: evaluation of #{exec_method} took longer than #{time_limit}ms.", trace_point, caller.to_a)
+            trace_queue << TimeLimitError.new("Timeout: evaluation of #{exec_method} took longer than #{time_limit}ms.", caller.to_a)
+            trace_point.disable
+            inspect_thread.kill
           end
+
+          next unless rand > 0.75
 
           curr_alloc_size = ObjectSpace.memsize_of_all
           start_alloc_size = curr_alloc_size if curr_alloc_size < start_alloc_size
 
           if curr_alloc_size - start_alloc_size > 1e6 * memory_limit
-            curr_thread.raise MemoryLimitError.new("Out of memory: evaluation of #{exec_method} took more than #{memory_limit}mb.", trace_point, caller.to_a)
+            trace_queue << MemoryLimitError.new("Out of memory: evaluation of #{exec_method} took more than #{memory_limit}mb.", caller.to_a)
+            trace_point.disable
+            inspect_thread.kill
           end
         end
         trace_point.enable
         result = value.send exec_method
+        trace_queue << result
         trace_point.disable
       end
-      inspect_thread.join
-      return result
-    rescue ExecError => e
-      e.trace_point.disable
-      print_debug(e.message + "\n" + e.backtrace.map {|l| "\t#{l}"}.join("\n"))
-      return overflow_message_type.call(e)
-    rescue JrubyTimeLimitError => e
+
+      while(mes = trace_queue.pop)
+        if(mes.is_a? TimeLimitError or mes.is_a? MemoryLimitError)
+          print_debug(mes.message + "\n" + mes.backtrace.map {|l| "\t#{l}"}.join("\n"))
+          return overflow_message_type.call(mes)
+        else
+          return mes
+        end
+      end
+    rescue SimpleTimeLimitError => e
       print_debug(e.message)
       return overflow_message_type.call(e)
-    ensure
-      inspect_thread.kill if inspect_thread && inspect_thread.alive?
     end
 
     def print_variable(name, value, kind)

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -189,8 +189,9 @@ module Debugger
     end
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
-      return exec_with_timeout(time_limit * 1e-3) {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0' && time_limit > 0)
       return value.send exec_method if !Debugger.trace_to_s
+      return exec_with_timeout(time_limit * 1e-3) {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0' && time_limit > 0)
+
 
       curr_thread = Thread.current
       control_thread = Debugger.control_thread

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -191,9 +191,8 @@ module Debugger
     end
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
-      return value.send exec_method if RUBY_VERSION < '2.0'
-
       return jruby_timeout(time_limit/1e3) {value.send exec_method} if defined?(JRUBY_VERSION)
+      return value.send exec_method if RUBY_VERSION < '2.0'
 
       curr_thread = Thread.current
 

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -13,7 +13,7 @@ module Debugger
     SPECIAL_SYMBOL_MESSAGE = lambda {|e| '<?>'}
   end
 
-  class ExecError < StandardError
+  class ExecError
     attr_reader :message
     attr_reader :backtrace
 


### PR DESCRIPTION
http://blog.headius.com/2008/02/rubys-threadraise-threadkill-timeoutrb.html 
Implementation with exceptions works quite unstable, so I had to rewrite it to blocking queue