### PR TITLE
2.5.0 does not produce an empty statement

### DIFF
--- a/lib/ruby-debug-ide/commands/expression_info.rb
+++ b/lib/ruby-debug-ide/commands/expression_info.rb
@@ -30,7 +30,7 @@ module Debugger
       end
 
       incomplete = true
-      if /\A\s*\Z/m =~ last_statement
+      if /\A\s*\Z/m =~ last_statement || !last_statement.end_with?("\n\n")
         incomplete = false
       end
 

--- a/lib/ruby-debug-ide/commands/expression_info.rb
+++ b/lib/ruby-debug-ide/commands/expression_info.rb
@@ -9,7 +9,7 @@ module Debugger
     end
 
     def execute
-      string_to_parse = Command.unescape_incoming(@match.post_match) + "\n\n\n"
+      string_to_parse = Command.unescape_incoming(@match.post_match) + " \n\n\n"
       total_lines = string_to_parse.count("\n") + 1
 
       lexer = RubyLex.new
@@ -30,7 +30,7 @@ module Debugger
       end
 
       incomplete = true
-      if /\A\s*\Z/m =~ last_statement || !last_statement.end_with?("\n\n")
+      if /\A\s*\Z/m =~ last_statement
         incomplete = false
       end
 


### PR DESCRIPTION
Now new line token is a condition for continued  command, so the whitespace was added to the end of the command
https://github.com/ruby/ruby/commit/f14f0d34641ece73d77781856eed70de760f9d9f