### PR TITLE
reverted back to require 'objspace'

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -49,7 +49,11 @@ EOB
 
   ENV['INSPECT_TIME_LIMIT'] = '100'
   opts.on("-t", "--time-limit LIMIT", Integer, "evaluation time limit in milliseconds (default: 100)") do |limit|
-    ENV['INSPECT_TIME_LIMIT'] = limit.to_s
+    if(limit <= 0)
+      Debugger.trace_to_s = false
+    else
+      ENV['INSPECT_TIME_LIMIT'] = limit.to_s
+    end
   end
 
   opts.on("-h", "--host HOST", "Host name used for remote debugging") {|host| options.host = host}

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -190,7 +190,7 @@ module Debugger
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
       return value.send exec_method if !Debugger.trace_to_s
-      return exec_with_timeout(time_limit * 1e-3, "Timeout: evaluation of #{exec_method} took longer than #{time_limit}ms.") {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0' && time_limit > 0)
+      return exec_with_timeout(time_limit * 1e-3, "Timeout: evaluation of #{exec_method} took longer than #{time_limit}ms.") {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0')
 
 
       curr_thread = Thread.current

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -190,7 +190,7 @@ module Debugger
 
     def exec_with_allocation_control(value, memory_limit, time_limit, exec_method, overflow_message_type)
       return value.send exec_method if !Debugger.trace_to_s
-      return exec_with_timeout(time_limit * 1e-3, "Timeout: evaluation of #{exec_method} took longer than #{time_limit}ms.") {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || (RUBY_VERSION < '2.0')
+      return exec_with_timeout(time_limit * 1e-3, "Timeout: evaluation of #{exec_method} took longer than #{time_limit}ms.") {value.send exec_method} if defined?(JRUBY_VERSION) || memory_limit <= 0 || RUBY_VERSION < '2.0'
 
 
       curr_thread = Thread.current

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -1,8 +1,8 @@
 require 'stringio'
 require 'cgi'
 require 'monitor'
-if (!defined?(JRUBY_VERSION))
-  include ObjectSpace
+if (!defined?(JRUBY_VERSION) && RUBY_VERSION >= "2.0")
+  require 'objspace'
 end
 
 module Debugger

--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -1,7 +1,7 @@
 require 'stringio'
 require 'cgi'
 require 'monitor'
-if (!defined?(JRUBY_VERSION) && RUBY_VERSION >= "2.0")
+if (!defined?(JRUBY_VERSION) && RUBY_VERSION >= '2.0')
   require 'objspace'
 end
 


### PR DESCRIPTION
memsize_of_all was added only in 1.9.3 (https://github.com/ruby/ruby/blob/c08f7b80889b531865e74bc5f573df8fa27f2088/doc/NEWS-1.9.3)
And anyway objectspace is useless version is < 2.0, because there is no TracePoint and tracing at all