### PR TITLE
deleted check if instance has `object_id` method

### DIFF
--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -279,7 +279,7 @@ module Debugger
       print("<variable name=\"%s\" %s kind=\"%s\" %s type=\"%s\" hasChildren=\"%s\" objectId=\"%#+x\">",
             CGI.escapeHTML(name), build_compact_value_attr(value, value_str), kind,
             build_value_attr(escaped_value_str), value.class,
-            has_children, value.respond_to?(:object_id) ? value.object_id : value.id)
+            has_children, value.object_id)
       print("<value><![CDATA[%s]]></value>", escaped_value_str) if Debugger.value_as_nested_element
       print('</variable>')
     rescue StandardError => e


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/RUBY-20602
Mocha framework redefines the `respond_to?` method and it turns out that the variable does not have an `object_id` method so we call an `id` method (which has a side effect)