### PR TITLE
new strategy of notifying the dispatcher

### DIFF
--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -119,9 +119,10 @@ module Debugger
           # "localhost" and nil have problems on some systems.
           host ||= '127.0.0.1'
 
-          server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port|
-            print_greeting_msg($stderr, host, real_port)
-            TCPServer.new(host, real_port) if defined? IDE_VERSION
+          server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port, port_changed = false|
+            server = TCPServer.new(host, real_port) if defined? IDE_VERSION
+            print_greeting_msg $stderr, host, real_port, port_changed ? "Subprocess" : "Fast"
+            server
           end
 
           return unless server
@@ -170,7 +171,7 @@ module Debugger
             port = Debugger.find_free_port(host)
           end
 
-          server = yield port
+          server = yield port, dispatcher_answer == "true"
 
           s.print(port)
           s.close

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -120,8 +120,8 @@ module Debugger
           host ||= '127.0.0.1'
 
           server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port, port_changed = false|
-            server = TCPServer.new(host, real_port) if defined? IDE_VERSION
-            print_greeting_msg $stderr, host, real_port, port_changed ? "Subprocess" : "Fast"
+            server = TCPServer.new(host, real_port)
+            print_greeting_msg $stderr, host, real_port, port_changed ? "Subprocess" : "Fast" if defined? IDE_VERSION
             server
           end
 

--- a/lib/ruby-debug-ide/greeter.rb
+++ b/lib/ruby-debug-ide/greeter.rb
@@ -10,7 +10,7 @@ require 'ruby-debug-ide/ide_processor'
 module Debugger
 
   class << self
-    def print_greeting_msg(stream, host, port)
+    def print_greeting_msg(stream, host, port, debugger_name = "Fast")
       base_gem_name = if defined?(JRUBY_VERSION) || RUBY_VERSION < '1.9.0'
                         'ruby-debug-base'
                       elsif RUBY_VERSION < '2.0.0'
@@ -31,7 +31,7 @@ module Debugger
         listens_on = "\n"
       end
 
-      msg = "Fast Debugger (ruby-debug-ide #{IDE_VERSION}, #{base_gem_name} #{VERSION}, file filtering is #{file_filtering_support})" + listens_on
+      msg = "#{debugger_name} Debugger (ruby-debug-ide #{IDE_VERSION}, #{base_gem_name} #{VERSION}, file filtering is #{file_filtering_support})" + listens_on
 
       stream.printf msg
     end

--- a/lib/ruby-debug-ide/multiprocess/pre_child.rb
+++ b/lib/ruby-debug-ide/multiprocess/pre_child.rb
@@ -11,7 +11,7 @@ module Debugger
             'frame_bind'  => false,
             'host'        => host,
             'load_mode'   => false,
-            'port'        => find_free_port(host),
+            'port'        => Debugger.find_free_port(host),
             'stop'        => false,
             'tracing'     => false,
             'int_handler' => true,
@@ -24,7 +24,7 @@ module Debugger
         )
 
         if(options.ignore_port)
-          options.port = find_free_port(options.host)
+          options.port = Debugger.find_free_port(options.host)
           options.notify_dispatcher = true
         end
       
@@ -53,14 +53,6 @@ module Debugger
         Debugger.inspect_time_limit = options.inspect_time_limit
         Debugger.cli_debug = options.cli_debug
         Debugger.prepare_debugger(options)
-      end
-
-
-      def find_free_port(host)
-        server = TCPServer.open(host, 0)
-        port   = server.addr[1]
-        server.close
-        port
       end
     end
   end

--- a/lib/ruby-debug-ide/version.rb
+++ b/lib/ruby-debug-ide/version.rb
@@ -1,3 +1,3 @@
 module Debugger
-  IDE_VERSION='0.6.1'
+  IDE_VERSION='0.7.0.beta1'
 end

--- a/lib/ruby-debug-ide/version.rb
+++ b/lib/ruby-debug-ide/version.rb
@@ -1,3 +1,3 @@
 module Debugger
-  IDE_VERSION='0.7.0.beta1'
+  IDE_VERSION='0.7.0.beta2'
 end


### PR DESCRIPTION
Now every new ruby process first ask the dispatcher in it's master debug process already started. And if not he becomes master himself. Also all sub-debugger print other greeting message than master