### PR TITLE
Fixed syntax error on ruby 1.8

### DIFF
--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -120,7 +120,7 @@ module Debugger
           # "localhost" and nil have problems on some systems.
           host ||= '127.0.0.1'
 
-          server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port, port_changed = false|
+          server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port, port_changed|
             s = TCPServer.new(host, real_port)
             print_greeting_msg $stderr, host, real_port, port_changed ? "Subprocess" : "Fast" if defined? IDE_VERSION
             s


### PR DESCRIPTION
Ruby 1.8 does not support default value in block arguments. I have no idea about the project is still support Ruby 1.8, but when notify_dispatcher_if_needed method yield, the 2nd argument that named port_changed cannot be nil. So, I've removed setting false as the default value of an argument.