### PR TITLE
create sockets with SO_REUSEPORT option

### DIFF
--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -166,6 +166,7 @@ module Debugger
 
       3.times do |i|
         begin
+          $stderr.puts "#{Process.pid}: go create dispatcher socket #{acceptor_host} #{acceptor_port}"
           s = TCPSocket.open(acceptor_host, acceptor_port)
           dispatcher_answer = s.gets.chomp
 

--- a/lib/ruby-debug-ide/command.rb
+++ b/lib/ruby-debug-ide/command.rb
@@ -173,7 +173,7 @@ module Debugger
       if filename.index(File::SEPARATOR) || File::ALT_SEPARATOR && filename.index(File::ALT_SEPARATOR)
         filename = File.expand_path(filename)
       end
-      if (RUBY_VERSION < '1.9') || (RbConfig::CONFIG['host_os'] =~ /mswin/)
+      if (RUBY_VERSION < '1.9') || Debugger.is_windows
         filename
       else
         filename = File.realpath(filename) rescue filename

--- a/lib/ruby-debug-ide/multiprocess/pre_child.rb
+++ b/lib/ruby-debug-ide/multiprocess/pre_child.rb
@@ -5,13 +5,11 @@ module Debugger
         require 'socket'
         require 'ostruct'
 
-        host = ENV['DEBUGGER_HOST']
-
         options ||= OpenStruct.new(
             'frame_bind'  => false,
-            'host'        => host,
+            'host'        => ENV['DEBUGGER_HOST'],
             'load_mode'   => false,
-            'port'        => Debugger.find_free_port(host),
+            'port'        => ENV['DEBUGGER_PORT'],
             'stop'        => false,
             'tracing'     => false,
             'int_handler' => true,
@@ -23,8 +21,7 @@ module Debugger
             'inspect_time_limit' => 100
         )
 
-        if(options.ignore_port)
-          options.port = Debugger.find_free_port(options.host)
+        if options.ignore_port
           options.notify_dispatcher = true
         end
       


### PR DESCRIPTION
Often in the case of a remote connection, there is a problem with the fact that debugger use several ports in case of multi-process applications. It turns out that there is an opportunity to create several sockets on the same port - REUSEPORT(REUSEADDR in case of windows)(https://stackoverflow.com/a/14388707/4863418)
According this answer REUSEPORT will work on linux starting with 3.9 kernel version(which was released back in 2013 so we are OK)


Old workaround: https://github.com/ruby-debug/ruby-debug-ide/issues/73