### PR TITLE
allow clients to connect over unix domain sockets

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -28,7 +28,8 @@ options = OpenStruct.new(
     'value_as_nested_element' => false,
     'attach_mode' => false,
     'cli_debug' => false,
-    'key_value_mode' => false
+    'key_value_mode' => false,
+    'socket_path' => nil
 )
 
 opts = OptionParser.new do |opts|
@@ -97,6 +98,9 @@ EOB
   end
   opts.on("--value-as-nested-element", "Allow to pass variable's value as nested element instead of attribute") do
     options.value_as_nested_element = true
+  end
+  opts.on("--socket-path PATH", "Listen for debugger on the given UNIX domain socket path") do |path|
+    options.socket_path = path
   end
   opts.separator ""
   opts.separator "Common options:"

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -73,17 +73,17 @@ module Debugger
       end
     end
 
-    def start_server(host = nil, port = 1234, notify_dispatcher = false)
+    def start_server(host = nil, port = 1234, notify_dispatcher = false, socket_path: nil)
       return if started?
       start
-      start_control(host, port, notify_dispatcher)
+      start_control(host, port, notify_dispatcher, socket_path: socket_path)
     end
 
     def prepare_debugger(options)
       @mutex = Mutex.new
       @proceed = ConditionVariable.new
 
-      start_server(options.host, options.port, options.notify_dispatcher)
+      start_server(options.host, options.port, options.notify_dispatcher, socket_path: options.socket_path)
 
       raise "Control thread did not start (#{@control_thread}}" unless @control_thread && @control_thread.alive?
 
@@ -111,25 +111,38 @@ module Debugger
       end
     end
 
-    def start_control(host, port, notify_dispatcher)
+    def start_control(host, port, notify_dispatcher, socket_path: nil)
       raise "Debugger is not started" unless started?
       return if @control_thread
       @control_thread = DebugThread.new do
         begin
-          # 127.0.0.1 seemingly works with all systems and with IPv6 as well.
-          # "localhost" and nil have problems on some systems.
-          host ||= '127.0.0.1'
+          if socket_path.nil?
+            # 127.0.0.1 seemingly works with all systems and with IPv6 as well.
+            # "localhost" and nil have problems on some systems.
+            host ||= '127.0.0.1'
 
-          server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port, port_changed|
-            s = TCPServer.new(host, real_port)
-            print_greeting_msg $stderr, host, real_port, port_changed ? "Subprocess" : "Fast" if defined? IDE_VERSION
-            s
+            server = notify_dispatcher_if_needed(host, port, notify_dispatcher) do |real_port, port_changed|
+              s = TCPServer.new(host, real_port)
+              print_greeting_msg $stderr, host, real_port, port_changed ? "Subprocess" : "Fast" if defined? IDE_VERSION
+              s
+            end
+          else
+            raise "Cannot specify host and socket_file at the same time" if host
+            File.delete(socket_path) if File.exist?(socket_path)
+            server = UNIXServer.new(socket_path)
+            print_greeting_msg $stderr, nil, nil, "Fast", socket_path: socket_path if defined? IDE_VERSION
           end
 
           return unless server
 
           while (session = server.accept)
-            $stderr.puts "Connected from #{session.peeraddr[2]}" if Debugger.cli_debug
+            if Debugger.cli_debug
+              if session.peeraddr == 'AF_INET'
+                $stderr.puts "Connected from #{session.peeraddr[2]}"
+              else
+                $stderr.puts "Connected from local client"
+              end
+            end
             dispatcher = ENV['IDE_PROCESS_DISPATCHER']
             if dispatcher
               ENV['IDE_PROCESS_DISPATCHER'] = "#{session.peeraddr[2]}:#{dispatcher}" unless dispatcher.include?(":")

--- a/lib/ruby-debug-ide/greeter.rb
+++ b/lib/ruby-debug-ide/greeter.rb
@@ -10,7 +10,7 @@ require 'ruby-debug-ide/ide_processor'
 module Debugger
 
   class << self
-    def print_greeting_msg(stream, host, port, debugger_name = "Fast")
+    def print_greeting_msg(stream, host, port, debugger_name = "Fast", socket_path: nil)
       base_gem_name = if defined?(JRUBY_VERSION) || RUBY_VERSION < '1.9.0'
                         'ruby-debug-base'
                       elsif RUBY_VERSION < '2.0.0'
@@ -27,6 +27,8 @@ module Debugger
 
       if host && port
         listens_on = " listens on #{host}:#{port}\n"
+      elsif socket_path
+        listens_on = " listens on #{socket_path}\n"
       else
         listens_on = "\n"
       end

--- a/test-base/catchpoint_test.rb
+++ b/test-base/catchpoint_test.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+$:.unshift File.join(File.dirname(__FILE__), "..", "lib")
+
+require 'test_base'
+
+module CatchpointTest
+
+  def test_catchpoint_basics
+    create_socket ['sleep 0.01', '5/0', 'sleep 0.01']
+    run_to_line(1)
+    send_next
+    assert_suspension(@test_path, 2, 1)
+    send_ruby('catch ZeroDivisionError')
+    assert_catchpoint_set('ZeroDivisionError')
+    send_next
+    assert_exception(@test_path, 2, 'ZeroDivisionError')
+    send_next
+  end
+
+end

--- a/test-base/enable_disable_test.rb
+++ b/test-base/enable_disable_test.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+$:.unshift File.join(File.dirname(__FILE__), "..", "lib")
+
+require 'test_base'
+
+module EnableDisableTest
+
+  def test_enable_disable_basics
+    create_socket ['1.upto(10) do', 'sleep 0.01', 'sleep 0.01', 'end']
+
+    send_test_breakpoint(2)
+    assert_breakpoint_added_no(1)
+    send_test_breakpoint(3)
+    assert_breakpoint_added_no(2)
+
+    start_debugger
+    assert_test_breakpoint(2)
+    send_cont
+    assert_test_breakpoint(3)
+    send_cont
+    assert_test_breakpoint(2)
+    send_ruby('disable 2')
+    assert_breakpoint_disabled(2)
+    send_cont
+    assert_test_breakpoint(2)
+    send_cont
+    assert_test_breakpoint(2)
+    send_ruby('enable 2')
+    assert_breakpoint_enabled(2)
+    send_cont
+    assert_test_breakpoint(3)
+    send_cont
+    assert_test_breakpoint(2)
+    send_cont
+    assert_test_breakpoint(3)
+    send_ruby('disable 1')
+    assert_breakpoint_disabled(1)
+    send_ruby('disable 2')
+    assert_breakpoint_disabled(2)
+    send_cont
+  end
+
+end

--- a/test/rd_basic_test.rb
+++ b/test/rd_basic_test.rb
@@ -8,3 +8,8 @@ class RDSteppingAndBreakpointsTest < RDTestBase
   include BasicTest
 
 end
+
+class RDUNIXSteppingAndBreakpointsTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include BasicTest
+end

--- a/test/rd_catchpoint_test.rb
+++ b/test/rd_catchpoint_test.rb
@@ -1,20 +1,15 @@
 #!/usr/bin/env ruby
 
 require 'rd_test_base'
+require 'catchpoint_test'
 
 class RDCatchpointTest < RDTestBase
 
-  def test_catchpoint_basics
-    create_socket ['sleep 0.01', '5/0', 'sleep 0.01']
-    run_to_line(1)
-    send_next
-    assert_suspension(@test_path, 2, 1)
-    send_ruby('catch ZeroDivisionError')
-    assert_catchpoint_set('ZeroDivisionError')
-    send_next
-    assert_exception(@test_path, 2, 'ZeroDivisionError')
-    send_next
-  end
-  
+  include CatchpointTest
+
 end
 
+class RDUNIXCatchpointTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include CatchpointTest
+end

--- a/test/rd_condition_test.rb
+++ b/test/rd_condition_test.rb
@@ -9,3 +9,7 @@ class RDConditionTest < RDTestBase
 
 end
 
+class RDUNIXConditionTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include ConditionTest
+end

--- a/test/rd_enable_disable_test.rb
+++ b/test/rd_enable_disable_test.rb
@@ -1,43 +1,15 @@
 #!/usr/bin/env ruby
 
 require 'rd_test_base'
+require 'enable_disable_test'
 
 class RDEnableDisableTest < RDTestBase
 
-  def test_enable_disable_basics
-    create_socket ['1.upto(10) do', 'sleep 0.01', 'sleep 0.01', 'end']
-    
-    send_test_breakpoint(2)
-    assert_breakpoint_added_no(1)
-    send_test_breakpoint(3)
-    assert_breakpoint_added_no(2)
-    
-    start_debugger
-    assert_test_breakpoint(2)
-    send_cont
-    assert_test_breakpoint(3)
-    send_cont
-    assert_test_breakpoint(2)
-    send_ruby('disable 2')
-    assert_breakpoint_disabled(2)
-    send_cont
-    assert_test_breakpoint(2)
-    send_cont
-    assert_test_breakpoint(2)
-    send_ruby('enable 2')
-    assert_breakpoint_enabled(2)
-    send_cont
-    assert_test_breakpoint(3)
-    send_cont
-    assert_test_breakpoint(2)
-    send_cont
-    assert_test_breakpoint(3)
-    send_ruby('disable 1')
-    assert_breakpoint_disabled(1)
-    send_ruby('disable 2')
-    assert_breakpoint_disabled(2)
-    send_cont
-  end
+  include EnableDisableTest
 
 end
 
+class RDUNIXEnableDisableTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include EnableDisableTest
+end

--- a/test/rd_expression_info_test.rb
+++ b/test/rd_expression_info_test.rb
@@ -9,3 +9,7 @@ class RDExpressionInfoTest < RDTestBase
 
 end
 
+class RDUNIXExpressionInfoTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include ExpressionInfoTest
+end

--- a/test/rd_inspect_test.rb
+++ b/test/rd_inspect_test.rb
@@ -9,3 +9,7 @@ class RDInspectTest < RDTestBase
 
 end
 
+class RDUNIXInspectTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include InspectTest
+end

--- a/test/rd_stepping_breakpoints_test.rb
+++ b/test/rd_stepping_breakpoints_test.rb
@@ -34,3 +34,7 @@ class RDSteppingAndBreakpointsTest < RDTestBase
 
 end
 
+class RDUNIXSteppingAndBreakpointsTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include SteppingAndBreakpointsTest
+end

--- a/test/rd_test_base.rb
+++ b/test/rd_test_base.rb
@@ -18,13 +18,20 @@ class RDTestBase < TestBase
     end
   end
 
-  def debug_command(script, port, additional_opts='')
+  def debug_command(script, port, socket_path, additional_opts='')
+    location_arg = if !port.nil?
+                     "-p #{port}"
+                   elsif !socket_path.nil?
+                     "--socket-path #{socket_path}"
+                   else
+                     raise StandardError, "One of port and socket_path must be set"
+                   end
     cmd = "#{interpreter}"
     cmd << " --debug" if jruby?
     cmd << " -J-Xdebug -J-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y" if jruby? and debug_jruby?
     cmd << " -I 'lib:#{File.dirname(script)}' #{@rdebug_ide}" +
       (@verbose_server ? " -d" : "") +
-        " -p #{port} #{additional_opts} -- '#{script}'"
+        " #{location_arg} #{additional_opts} -- '#{script}'"
   end
 
   def start_debugger

--- a/test/rd_threads_and_frames_test.rb
+++ b/test/rd_threads_and_frames_test.rb
@@ -9,3 +9,7 @@ class RDThreadsAndFrames < RDTestBase
 
 end
 
+class RDUNIXThreadsAndFrames < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include ThreadsAndFrames
+end

--- a/test/rd_variables_test.rb
+++ b/test/rd_variables_test.rb
@@ -9,3 +9,7 @@ class RDVariablesTest < RDTestBase
 
 end
 
+class RDUNIXVariablesTest < RDTestBase
+  include TestBase::UseUNIXDomainSocket
+  include VariablesTest
+end


### PR DESCRIPTION
Allow debugger clients to connect to the in-process debug server over a UNIX domain socket instead of a local TCP socket. My company has been running a variant of this PR (against a 0.6.x release) internally since last September. 

- `start_server` takes an additional `socket_path` argument. An error is raised if the `host` parameter is also provided at the same time. I'd love suggestions on how to improve the API.

- The PR refactors the tests enough to allow testing both the TCP socket and UNIX domain socket variants with the same test code.