### PR TITLE
Added option to skip watting for start command

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -17,6 +17,7 @@ options = OpenStruct.new(
     'port'        => 1234,
     'stop'        => false,
     'tracing'     => false,
+    'skip_wait_for_start' => false,
     'int_handler' => true,
     'dispatcher_port' => -1,
     'evaluation_timeout' => 10,
@@ -67,6 +68,7 @@ EOB
 
   opts.on('--stop', 'stop when the script is loaded') {options.stop = true}
   opts.on("-x", "--trace", "turn on line tracing") {options.tracing = true}
+  opts.on("--skip_wait_for_start", "skip wait for 'start' command") {options.skip_wait_for_start = true}
   opts.on("-l", "--load-mode", "load mode (experimental)") {options.load_mode = true}
   opts.on("-d", "--debug", "Debug self - prints information for debugging ruby-debug itself") do
     Debugger.cli_debug = true

--- a/lib/ruby-debug-ide.rb
+++ b/lib/ruby-debug-ide.rb
@@ -90,7 +90,7 @@ module Debugger
       # wait for 'start' command
       @mutex.synchronize do
         @proceed.wait(@mutex)
-      end
+      end unless options.skip_wait_for_start
     end
 
     def debug_program(options)

--- a/ruby-debug-ide.gemspec
+++ b/ruby-debug-ide.gemspec
@@ -45,7 +45,4 @@ EOF
   spec.required_ruby_version = '>= 1.8.2'
   spec.date = DateTime.now
   spec.rubyforge_project = 'debug-commons'
-
-  # rdoc
-  spec.has_rdoc = false
 end


### PR DESCRIPTION
I always keep the server running and use VSCode to attach to the active process.
So it is more useful to skip the "wait for a start command" line.