### PR TITLE
Fix failed build on MacOS 10.15, Ruby 2.6.3

### DIFF
--- a/ruby-debug-ide.gemspec
+++ b/ruby-debug-ide.gemspec
@@ -38,8 +38,6 @@ EOF
   spec.bindir = "bin"
   spec.executables = ["rdebug-ide", "gdb_wrapper"]
   spec.files = FILES
-
-  spec.extensions << "ext/mkrf_conf.rb" unless ENV['NO_EXT']
   spec.add_dependency("rake", ">= 0.8.1")
 
   spec.required_ruby_version = '>= 1.8.2'


### PR DESCRIPTION
Hi, I'm using MacOS 10.15 and ruby 2.6.3p62, rails 5.2.3. And I can't build this gem since update to macOS Catalina (10.15). Here's just my temporary fix solution, can you review it?

```
Building native extensions. This could take a while...
ERROR:  Error installing debase:
        ERROR: Failed to build gem native extension.

    current directory: /Library/Ruby/Gems/2.6.0/gems/debase-0.2.4.1/ext
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r ./siteconf20191019-16088-165bduw.rb extconf.rb
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

```