### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/ruby-debug-ide.gemspec
+++ b/ruby-debug-ide.gemspec
@@ -44,5 +44,4 @@ EOF
 
   spec.required_ruby_version = '>= 1.8.2'
   spec.date = DateTime.now
-  spec.rubyforge_project = 'debug-commons'
 end


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436