### PR TITLE
`eval` command: Escape HTML on the evaluated value.

### DIFF
--- a/lib/ruby-debug-ide/xml_printer.rb
+++ b/lib/ruby-debug-ide/xml_printer.rb
@@ -382,7 +382,7 @@ module Debugger
     end
 
     def print_eval(exp, value)
-      print "<eval expression=\"%s\" value=\"%s\" />", CGI.escapeHTML(exp), value
+      print "<eval expression=\"%s\" value=\"%s\" />", CGI.escapeHTML(exp), CGI.escapeHTML(value)
     end
 
     def print_pp(value)


### PR DESCRIPTION
Many things that evaluates to a string do not work properly without this escape. For example:

* `""`
* `" "`
* `[].join` (which produces `" "`)

Fixes a bug where the debug console in VS Code can _hang the debugger_ when inserting one of those types of input.

I could not find tests for this routine. If I missed any, let me know!